### PR TITLE
Fix byte conversion error in 32-bit systems

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -350,7 +350,7 @@ impl Message {
                 attrs_buf.remove(0),
             ]));
             let length =
-                usize::from_be_bytes([0, 0, 0, 0, 0, 0, attrs_buf.remove(0), attrs_buf.remove(0)]);
+                u16::from_be_bytes([attrs_buf.remove(0), attrs_buf.remove(0)]) as usize;
             if attrs_buf.len() < length {
                 return Err(STUNClientError::ParseError());
             }


### PR DESCRIPTION
Previously, the conversion of two bytes to a usize was causing an error in 32-bit systems because usize was expecting a 4-byte array in these systems.

This commit fixes this issue by first converting the two bytes to a u16 (which is always 2 bytes regardless of the system), and then casting the result to a usize. This ensures that the code works correctly on both 32-bit and 64-bit systems.